### PR TITLE
[JENKINS-35735] Fixes for IE compatibility

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -144,7 +144,7 @@ exports.requireModule = function(moduleQName) {
  * the loading of this module.
  * @param onError On error callback;
  */
-exports.export = function(namespace, moduleName, module, onError) {
+exports.exportModule = function(namespace, moduleName, module, onError) {
     try {
         var moduleQName = (namespace ? namespace + ':' : '') + moduleName;
         var moduleSpec = new ModuleSpec(moduleQName);

--- a/js/index.js
+++ b/js/index.js
@@ -132,7 +132,7 @@ exports.requireModule = function(moduleQName) {
             "The module needs to have been asynchronously pre-loaded via an outer call to 'import'.");
     }
     return module.exports;
-}
+};
 
 /**
  * Export a module.

--- a/js/index.js
+++ b/js/index.js
@@ -124,7 +124,7 @@ exports.importModule = function() {
  *
  * @return The module.
  */
-exports.require = function(moduleQName) {
+exports.requireModule = function(moduleQName) {
     var parsedModuleName = new ModuleSpec(moduleQName);
     var module = internal.getModule(parsedModuleName);    
     if (!module) {

--- a/js/index.js
+++ b/js/index.js
@@ -52,9 +52,9 @@ exports.whoami = function(moduleQName) {
  *
  * @return A Promise, allowing async load of all modules. The promise is only fulfilled when all modules are loaded.
  */
-exports.import = function() {
+exports.importModule = function() {
     if (arguments.length === 1) {
-        return internal.import(arguments[0], onRegisterTimeout);        
+        return internal.importModule(arguments[0], onRegisterTimeout);        
     }
     
     var moduleQNames = [];    
@@ -92,7 +92,7 @@ exports.import = function() {
         // doRequire for each module
         for (var i = 0; i < moduleQNames.length; i++) {           
             function doRequire(moduleQName) {
-                var promise = internal.import(moduleQName, onRegisterTimeout);
+                var promise = internal.importModule(moduleQName, onRegisterTimeout);
                 var fulfillment = {
                     promise: promise,
                     value: undefined
@@ -309,7 +309,7 @@ internal.onJenkinsGlobalInit(function(jenkinsCIGlobal) {
         // Put the functions on an object called '_internal' as a way
         // of hinting to people to not use it.
         jenkinsCIGlobal._internal = {
-            import: exports.import,
+            importModule: exports.importModule,
             addScript: internal.addScript
         };
     }

--- a/js/internal.js
+++ b/js/internal.js
@@ -90,7 +90,7 @@ exports.getNamespace = function(namespaceName) {
     return namespace;
 };
 
-exports.import = function(moduleQName, onRegisterTimeout) {
+exports.importModule = function(moduleQName, onRegisterTimeout) {
     return promise.make(function (resolve, reject) {
         var moduleSpec = new ModuleSpec(moduleQName);
         var module = exports.getModule(moduleSpec);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-modules",
-  "version": "0.0.6",
+  "version": "0.0.7-beta1",
   "description": "Jenkins CI JavaScript module bundle loader",
   "main": "js/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-modules",
-  "version": "0.0.7-beta1",
+  "version": "0.0.7",
   "description": "Jenkins CI JavaScript module bundle loader",
   "main": "js/index.js",
   "scripts": {

--- a/spec/import-version-ranges-spec.js
+++ b/spec/import-version-ranges-spec.js
@@ -47,7 +47,7 @@ describe("index.js", function () {
             expect(scriptEl).toBe(null);
             
             // Make sure we can synchronously get the module.
-            var mathUtils = jsmodules.require('pluginA:mathUtils@1.2.3');
+            var mathUtils = jsmodules.requireModule('pluginA:mathUtils@1.2.3');
             expect(mathUtils).toBeDefined();
             
             done();               
@@ -90,7 +90,7 @@ describe("index.js", function () {
             expect(scriptEl).toBe(null);
             
             // Make sure we can synchronously get the module.
-            var mathUtils = jsmodules.require('mathUtils@1.2.3');
+            var mathUtils = jsmodules.requireModule('mathUtils@1.2.3');
             expect(mathUtils).toBeDefined();
             
             done();               
@@ -128,7 +128,7 @@ describe("index.js", function () {
             });
             
             // Make sure we can synchronously get the module.
-            var mathUtils = jsmodules.require('mathUtils@1.2.3');
+            var mathUtils = jsmodules.requireModule('mathUtils@1.2.3');
             expect(mathUtils).toBeDefined();
             
             done();               
@@ -157,7 +157,7 @@ describe("index.js", function () {
             expect(document.getElementsByTagName('script').length).toBe(0);
             
             // Make sure we can synchronously get the module.
-            var mathUtils = jsmodules.require('mathUtils@any');
+            var mathUtils = jsmodules.requireModule('mathUtils@any');
             expect(mathUtils).toBeDefined();
             
             done();               
@@ -189,7 +189,7 @@ describe("index.js", function () {
             });
             
             // Make sure we can synchronously get the module.
-            var mathUtils = jsmodules.require('mathUtils@any');
+            var mathUtils = jsmodules.requireModule('mathUtils@any');
             expect(mathUtils).toBeDefined();
             
             done();               
@@ -221,7 +221,7 @@ describe("index.js", function () {
             });
             
             // Make sure we can synchronously get the module.
-            var mathUtils = jsmodules.require('mathUtils@1.2.x');
+            var mathUtils = jsmodules.requireModule('mathUtils@1.2.x');
             expect(mathUtils).toBeDefined();
             
             done();               

--- a/spec/import-version-ranges-spec.js
+++ b/spec/import-version-ranges-spec.js
@@ -34,7 +34,7 @@ describe("index.js", function () {
             // via adding of a <script> element to the page DOM. That plugin module
             // is then responsible for calling 'export', which should trigger
             // the notify etc
-            jsmodules.export('pluginA', 'mathUtils@1.2.3', {
+            jsmodules.exportModule('pluginA', 'mathUtils@1.2.3', {
                 add: function(lhs, rhs) {
                     return lhs + rhs;
                 }
@@ -77,7 +77,7 @@ describe("index.js", function () {
             // via adding of a <script> element to the page DOM. That plugin module
             // is then responsible for calling 'export', which should trigger
             // the notify etc
-            jsmodules.export(undefined, 'mathUtils@1.2.3', {
+            jsmodules.exportModule(undefined, 'mathUtils@1.2.3', {
                 add: function(lhs, rhs) {
                     return lhs + rhs;
                 }
@@ -121,7 +121,7 @@ describe("index.js", function () {
             // via adding of a <script> element to the page DOM. That plugin module
             // is then responsible for calling 'export', which should trigger
             // the notify etc
-            jsmodules.export(undefined, 'mathUtils@1.2.3', {
+            jsmodules.exportModule(undefined, 'mathUtils@1.2.3', {
                 add: function(lhs, rhs) {
                     return lhs + rhs;
                 }
@@ -140,7 +140,7 @@ describe("index.js", function () {
             var jsmodules = getJSModules();
 
             // Pre load/export the "any"
-            jsmodules.export(undefined, 'mathUtils@any', {
+            jsmodules.exportModule(undefined, 'mathUtils@any', {
                 add: function(lhs, rhs) {
                     return lhs + rhs;
                 }
@@ -182,7 +182,7 @@ describe("index.js", function () {
             
             // Now do the export so the import can be fullfilled and the test
             // can finish out cleanly
-            jsmodules.export(undefined, 'mathUtils@any', {
+            jsmodules.exportModule(undefined, 'mathUtils@any', {
                 add: function(lhs, rhs) {
                     return lhs + rhs;
                 }
@@ -214,7 +214,7 @@ describe("index.js", function () {
             
             // Now do the export so the import can be fullfilled and the test
             // can finish out cleanly
-            jsmodules.export(undefined, 'mathUtils@1.2.x', {
+            jsmodules.exportModule(undefined, 'mathUtils@1.2.x', {
                 add: function(lhs, rhs) {
                     return lhs + rhs;
                 }

--- a/spec/import-version-ranges-spec.js
+++ b/spec/import-version-ranges-spec.js
@@ -15,7 +15,7 @@ describe("index.js", function () {
         testUtil.onJenkinsPage(function() {
             var jsmodules = getJSModules();
             
-            jsmodules.import('pluginA:mathUtils@1.2.3', 2000).onFulfilled(function(module) {
+            jsmodules.importModule('pluginA:mathUtils@1.2.3', 2000).onFulfilled(function(module) {
                 expect(module.add(2,2)).toBe(4);
             }); // timeout before Jasmine does
             
@@ -58,7 +58,7 @@ describe("index.js", function () {
         testUtil.onJenkinsPage(function() {
             var jsmodules = getJSModules();
             
-            jsmodules.import('mathUtils@1.2.3', 2000).onFulfilled(function(module) {
+            jsmodules.importModule('mathUtils@1.2.3', 2000).onFulfilled(function(module) {
                 expect(module.add(2,2)).toBe(4);
             }); // timeout before Jasmine does
             
@@ -101,7 +101,7 @@ describe("index.js", function () {
         testUtil.onJenkinsPage(function() {
             var jsmodules = getJSModules();
             
-            jsmodules.import('mathUtils@any|1.2.3', 2000).onFulfilled(function(module) {
+            jsmodules.importModule('mathUtils@any|1.2.3', 2000).onFulfilled(function(module) {
                 expect(module.add(2,2)).toBe(4);
             }); // timeout before Jasmine does
             
@@ -146,7 +146,7 @@ describe("index.js", function () {
                 }
             });
             
-            jsmodules.import('mathUtils@any|1.2.3', 2000).onFulfilled(function(module) {
+            jsmodules.importModule('mathUtils@any|1.2.3', 2000).onFulfilled(function(module) {
                 expect(module.add(2,2)).toBe(4);
             }); // timeout before Jasmine does
             
@@ -170,7 +170,7 @@ describe("index.js", function () {
 
             // Don't pre load/export the "any"
            
-            jsmodules.import('mathUtils@any', 2000).onFulfilled(function(module) {
+            jsmodules.importModule('mathUtils@any', 2000).onFulfilled(function(module) {
                 expect(module.add(2,2)).toBe(4);
             }); // timeout before Jasmine does
             
@@ -202,7 +202,7 @@ describe("index.js", function () {
 
             // Don't pre load/export the "any"
            
-            jsmodules.import('mathUtils@1.2.x', 2000).onFulfilled(function(module) {
+            jsmodules.importModule('mathUtils@1.2.x', 2000).onFulfilled(function(module) {
                 expect(module.add(2,2)).toBe(4);
             }); // timeout before Jasmine does
             

--- a/spec/index-spec.js
+++ b/spec/index-spec.js
@@ -12,7 +12,7 @@ describe("index.js", function () {
             var jenkins = require("../js/index");
             
             try {
-                jenkins.require('pluginA:mathUtils');
+                jenkins.requireModule('pluginA:mathUtils');
             } catch (e) {
                 expect(e.message).toBe("Unable to perform synchronous 'require' for module 'pluginA:mathUtils'. This module is not pre-loaded. The module needs to have been asynchronously pre-loaded via an outer call to 'import'.");
             }
@@ -74,7 +74,7 @@ describe("index.js", function () {
             expect(scriptEl).toBe(null);
             
             // Make sure we can synchronously get the module.
-            var mathUtils = jenkins.require('pluginA:mathUtils');
+            var mathUtils = jenkins.requireModule('pluginA:mathUtils');
             expect(mathUtils).toBeDefined();
         });
     });
@@ -184,14 +184,14 @@ describe("index.js", function () {
                     expect(bootstrapCSSEl.getAttribute('href')).toBe('/jenkins/assets/bootstrap/jsmodules/bootstrap3/style.css');
 
                     // Test require ...
-                    jenkins.require('jquery:jquery2');
+                    jenkins.requireModule('jquery:jquery2');
                     // Specifying the namespace provider here should be irrelevant coz
                     // the bundle/module is already registered. That's the main point here i.e.
                     // the nsProvider is only of interest IF the module needs to be loaded i.e. it tells
                     // where to get the module from (the provider). If it's already loaded, then we don't
                     // care where it was loaded from.
-                    jenkins.require('core-assets/jquery:jquery2');
-                    jenkins.require('plugin/jquery:jquery2');
+                    jenkins.requireModule('core-assets/jquery:jquery2');
+                    jenkins.requireModule('plugin/jquery:jquery2');
 
                     done();
                 });
@@ -223,14 +223,14 @@ describe("index.js", function () {
                     expect(jqueryScriptEl.getAttribute('src')).toBe('/jenkins/assets/jquery/jsmodules/jquery2.js');
 
                     // Test require ...
-                    jenkins.require('jquery:jquery2');
+                    jenkins.requireModule('jquery:jquery2');
                     // Specifying the namespace provider here should be irrelevant coz
                     // the bundle/module is already registered. That's the main point here i.e.
                     // the nsProvider is only of interest IF the module needs to be loaded i.e. it tells
                     // where to get the module from (the provider). If it's already loaded, then we don't
                     // care where it was loaded from.
-                    jenkins.require('core-assets/jquery:jquery2');
-                    jenkins.require('plugin/jquery:jquery2');
+                    jenkins.requireModule('core-assets/jquery:jquery2');
+                    jenkins.requireModule('plugin/jquery:jquery2');
 
                     done();
                 });
@@ -564,7 +564,7 @@ describe("index.js", function () {
                     return lhs + rhs;
                 }
             });
-            jenkins.require('pluginA:mathUtils');
+            jenkins.requireModule('pluginA:mathUtils');
             done();
         }, '<html><head></head></html>');
     });

--- a/spec/index-spec.js
+++ b/spec/index-spec.js
@@ -19,7 +19,7 @@ describe("index.js", function () {
             
             // should fail because a export never happens
             jenkins.setRegisterTimeout(100);
-            jenkins.import('pluginA:mathUtils')
+            jenkins.importModule('pluginA:mathUtils')
                 .onRejected(function(error) {
                     expect(error.reason).toBe('timeout');
                     expect(error.detail).toBe("Timed out waiting on module 'pluginA:mathUtils' to load.");
@@ -35,7 +35,7 @@ describe("index.js", function () {
             // Require before the module is registered.
             // The require should "trigger" the loading of the module from the plugin.
             // Should pass because export will happen before the timeout
-            jenkins.import('pluginA:mathUtils', 2000).onFulfilled(function(module) {
+            jenkins.importModule('pluginA:mathUtils', 2000).onFulfilled(function(module) {
                 expect(module.add(2,2)).toBe(4);
                 done();               
             }); // timeout before Jasmine does
@@ -43,7 +43,7 @@ describe("index.js", function () {
             // Try requiring the module again immediately. Should be ignored i.e. a second
             // <script> element should NOT be added to the dom. See the test at the end
             // of this method.
-            jenkins.import('pluginA:mathUtils', 1000).onFulfilled(function(module) {
+            jenkins.importModule('pluginA:mathUtils', 1000).onFulfilled(function(module) {
             });
             
             // Check that the <script> element was added to the <head>
@@ -91,7 +91,7 @@ describe("index.js", function () {
             });
             
             // Should pass immediately because export has already happened.
-            jenkins.import('pluginA:mathUtils', 0).onFulfilled(function(module) {
+            jenkins.importModule('pluginA:mathUtils', 0).onFulfilled(function(module) {
                 expect(module.add(2,2)).toBe(4);
                 done();               
             }); // disable async load mode
@@ -108,7 +108,7 @@ describe("index.js", function () {
             // The require should "trigger" the loading of the module from the plugin.
             // Should pass because export will happen before the timeout
             jenkins.setRegisterTimeout(2000);
-            jenkins.import('pluginA:mathUtils', 'pluginB:timeUtils')
+            jenkins.importModule('pluginA:mathUtils', 'pluginB:timeUtils')
                 .onFulfilled(function(mathUtils, timeUtils) {
                     // This function should only be called once both modules have been exported
                     expect(mathUtils.add(2,2)).toBe(4);
@@ -162,7 +162,7 @@ describe("index.js", function () {
             jenkins.whoami('bootstrap:bootstrap3');
             expect(internal.whoami().nsProvider).toBe('core-assets');
 
-            jenkins.import('jquery:jquery2')
+            jenkins.importModule('jquery:jquery2')
                 .onFulfilled(function() {
                     // 'jquery:jquery2' should have also been loaded from the 'core-assets' namespace
                     // provider because the parent bundle ('bootstrap3') was loaded from 'core-assets'.
@@ -209,7 +209,7 @@ describe("index.js", function () {
 
             // Test import where the nsProvider is specified on the import. This is
             // slightly different to using the parent's provider namespace
-            jenkins.import('core-assets/jquery:jquery2')
+            jenkins.importModule('core-assets/jquery:jquery2')
                 .onFulfilled(function() {
                     // 'jquery:jquery2' should have also been loaded from the 'core-assets' namespace
                     // provider because the parent bundle ('bootstrap3') was loaded from 'core-assets'.
@@ -259,7 +259,7 @@ describe("index.js", function () {
             // Now require.
             // Should pass immediately because export has already happened for each plugin.
             jenkins.setRegisterTimeout(0);
-            jenkins.import('pluginA:mathUtils', 'pluginB:timeUtils') // disable async load mode
+            jenkins.importModule('pluginA:mathUtils', 'pluginB:timeUtils') // disable async load mode
                 .onFulfilled(function(mathUtils, timeUtils) {
                     // This function should only be called once both modules have been exported
                     expect(mathUtils.add(2,2)).toBe(4);
@@ -279,7 +279,7 @@ describe("index.js", function () {
             // Should pass because export will happen before the timeout
             jenkins.setRegisterTimeout(2000);
             var _internal = internal.getJenkins()._internal;
-            _internal.import('pluginA:mathUtils')
+            _internal.importModule('pluginA:mathUtils')
                 .onFulfilled(function(mathUtils) {
                     // This function should only be called once both modules have been exported
                     expect(mathUtils.add(2,2)).toBe(4);
@@ -304,7 +304,7 @@ describe("index.js", function () {
             // The require should "trigger" the loading of the module.
             // Should pass because export will happen before the timeout
             jenkins.setRegisterTimeout(2000);
-            jenkins.import('mathUtils', 'timeUtils')
+            jenkins.importModule('mathUtils', 'timeUtils')
                 .onFulfilled(function(mathUtils, timeUtils) {
                     // This function should only be called once both modules have been exported
                     expect(mathUtils.add(2,2)).toBe(4);
@@ -351,7 +351,7 @@ describe("index.js", function () {
             jenkins.setRegisterTimeout(2000);
             // 2 modules, the first is in the global namespace and the second is in a 
             // plugin namespace ('pluginB')
-            jenkins.import('mathUtils', 'pluginB:timeUtils')
+            jenkins.importModule('mathUtils', 'pluginB:timeUtils')
                 .onFulfilled(function(mathUtils, timeUtils) {
                     expect(mathUtils).toBeDefined();
                     expect(timeUtils).toBeDefined();

--- a/spec/index-spec.js
+++ b/spec/index-spec.js
@@ -61,7 +61,7 @@ describe("index.js", function () {
             // via adding of a <script> element to the page DOM. That plugin module
             // is then responsible for calling 'export', which should trigger
             // the notify etc
-            jenkins.export('pluginA', 'mathUtils', {
+            jenkins.exportModule('pluginA', 'mathUtils', {
                 add: function(lhs, rhs) {
                     return lhs + rhs;
                 }
@@ -84,7 +84,7 @@ describe("index.js", function () {
             var jenkins = require("../js/index");
 
             // Register the module before calling require. See above test too.
-            jenkins.export('pluginA', 'mathUtils', {
+            jenkins.exportModule('pluginA', 'mathUtils', {
                 add: function(lhs, rhs) {
                     return lhs + rhs;
                 }
@@ -128,12 +128,12 @@ describe("index.js", function () {
                 }); // timeout before Jasmine does
 
             // Now mimic registering of the plugin modules.
-            jenkins.export('pluginA', 'mathUtils', {
+            jenkins.exportModule('pluginA', 'mathUtils', {
                 add: function(lhs, rhs) {
                     return lhs + rhs;
                 }
             });
-            jenkins.export('pluginB', 'timeUtils', {
+            jenkins.exportModule('pluginB', 'timeUtils', {
                 now: function() {
                     return new Date(1000000000000);
                 }
@@ -197,7 +197,7 @@ describe("index.js", function () {
                 });
 
             // Now mimic registering of the plugin modules.
-            jenkins.export('jquery', 'jquery2', {});
+            jenkins.exportModule('jquery', 'jquery2', {});
         });
     });
 
@@ -236,7 +236,7 @@ describe("index.js", function () {
                 });
 
             // Now mimic registering of the plugin modules.
-            jenkins.export('jquery', 'jquery2', {});
+            jenkins.exportModule('jquery', 'jquery2', {});
         });
     });
 
@@ -245,12 +245,12 @@ describe("index.js", function () {
             var jenkins = require("../js/index");
             
             // Register the plugin modules before requiring.
-            jenkins.export('pluginA', 'mathUtils', {
+            jenkins.exportModule('pluginA', 'mathUtils', {
                 add: function(lhs, rhs) {
                     return lhs + rhs;
                 }
             });
-            jenkins.export('pluginB', 'timeUtils', {
+            jenkins.exportModule('pluginB', 'timeUtils', {
                 now: function() {
                     return new Date(1000000000000);
                 }
@@ -287,7 +287,7 @@ describe("index.js", function () {
                 }); // timeout before Jasmine does
             
             // Now mimic registering of the plugin modules.
-            jenkins.export('pluginA', 'mathUtils', {
+            jenkins.exportModule('pluginA', 'mathUtils', {
                 add: function(lhs, rhs) {
                     return lhs + rhs;
                 }
@@ -318,12 +318,12 @@ describe("index.js", function () {
                 }); // timeout before Jasmine does
             
             // Now mimic registering of the global modules (plugin name undefined).
-            jenkins.export(undefined, 'mathUtils', {
+            jenkins.exportModule(undefined, 'mathUtils', {
                 add: function(lhs, rhs) {
                     return lhs + rhs;
                 }
             });
-            jenkins.export(undefined, 'timeUtils', {
+            jenkins.exportModule(undefined, 'timeUtils', {
                 now: function() {
                     return new Date(1000000000000);
                 }
@@ -359,8 +359,8 @@ describe("index.js", function () {
                 }); // timeout before Jasmine does
             
             // Now mimic registering of the modules, but without actual "modules" i.e. 3rd param not defined.
-            jenkins.export(undefined, 'mathUtils');
-            jenkins.export('pluginB', 'timeUtils');
+            jenkins.exportModule(undefined, 'mathUtils');
+            jenkins.exportModule('pluginB', 'timeUtils');
         });
     });   
     
@@ -528,7 +528,7 @@ describe("index.js", function () {
     it("- test rootURL/resURL not defined", function (done) {
         testUtil.onJenkinsPage(function() {
             var jenkins = require("../js/index");
-            jenkins.export('pluginA', 'mathUtils', {
+            jenkins.exportModule('pluginA', 'mathUtils', {
                 add: function(lhs, rhs) {
                     return lhs + rhs;
                 }
@@ -559,7 +559,7 @@ describe("index.js", function () {
         testUtil.onJenkinsPage(function() {
             var jenkins = require("../js/index");
             jenkins.setRootURL('/jenkins');
-            jenkins.export('pluginA', 'mathUtils', {
+            jenkins.exportModule('pluginA', 'mathUtils', {
                 add: function(lhs, rhs) {
                     return lhs + rhs;
                 }


### PR DESCRIPTION
`import` and `export` are reserved keywords in JavaScript. Not a problem on other browsers (atm), but is a problem on IE. It can be worked around using a browserify transform (`es3ify`), but I really think we should just move the names away from there completely and the sooner we do it the better.