### PR TITLE
ResourceLocationResolver support

### DIFF
--- a/js/ResourceLocationResolver.js
+++ b/js/ResourceLocationResolver.js
@@ -1,0 +1,46 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+function ResourceLocationResolver(canResolveFunc, resolverFunc, ordinal) {
+    this.canResolveFunc = canResolveFunc;
+    this.resolverFunc = resolverFunc;
+    // Use an ordinal for crude ordering
+    if (typeof ordinal === 'number') {
+        this.ordinal = ordinal;
+    } else {
+        this.ordinal = Number.MAX_VALUE;
+    }
+}
+
+ResourceLocationResolver.prototype.canResolve = function(moduleSpec) {
+    return this.canResolveFunc(moduleSpec);
+};
+
+ResourceLocationResolver.sort = function (resolvers) {
+    resolvers.sort(function(r1, r2) {
+        return r2.ordinal - r1.ordinal;
+    });
+};
+
+module.exports = ResourceLocationResolver;

--- a/js/index.js
+++ b/js/index.js
@@ -54,24 +54,24 @@ exports.whoami = function(moduleQName) {
  */
 exports.importModule = function() {
     if (arguments.length === 1) {
-        return internal.importModule(arguments[0], onRegisterTimeout);        
+        return internal.importModule(arguments[0], onRegisterTimeout);
     }
-    
-    var moduleQNames = [];    
+
+    var moduleQNames = [];
     for (var i = 0; i < arguments.length; i++) {
         var argument = arguments[i];
         if (typeof argument === 'string') {
             moduleQNames.push(argument);
         }
     }
-    
+
     if (moduleQNames.length == 0) {
         throw new Error("No module names specified.");
     }
-    
+
     return promise.make(function (resolve, reject) {
         var fulfillments = [];
-        
+
         function onFulfillment() {
             if (fulfillments.length === moduleQNames.length) {
                 var modules = [];
@@ -87,10 +87,10 @@ exports.importModule = function() {
                 // means we can now fulfill the top level import promise.
                 resolve(modules);
             }
-        }        
-        
+        }
+
         // doRequire for each module
-        for (var i = 0; i < moduleQNames.length; i++) {           
+        for (var i = 0; i < moduleQNames.length; i++) {
             function doRequire(moduleQName) {
                 var promise = internal.importModule(moduleQName, onRegisterTimeout);
                 var fulfillment = {
@@ -109,7 +109,7 @@ exports.importModule = function() {
             }
             doRequire(moduleQNames[i]);
         }
-    }).applyArgsOnFulfill();    
+    }).applyArgsOnFulfill();
 };
 
 /**
@@ -126,7 +126,7 @@ exports.importModule = function() {
  */
 exports.requireModule = function(moduleQName) {
     var parsedModuleName = new ModuleSpec(moduleQName);
-    var module = internal.getModule(parsedModuleName);    
+    var module = internal.getModule(parsedModuleName);
     if (!module) {
         throw new Error("Unable to perform synchronous 'require' for module '" + moduleQName + "'. This module is not pre-loaded. " +
             "The module needs to have been asynchronously pre-loaded via an outer call to 'import'.");
@@ -136,10 +136,10 @@ exports.requireModule = function(moduleQName) {
 
 /**
  * Export a module.
- * 
+ *
  * @param namespace The namespace in which the module resides, or "undefined" if the modules is in
  * the "global" module namespace e.g. a Jenkins core bundle.
- * @param moduleName The name of the module. 
+ * @param moduleName The name of the module.
  * @param module The CommonJS style module, or "undefined" if we just want to notify other modules waiting on
  * the loading of this module.
  * @param onError On error callback;
@@ -183,22 +183,35 @@ exports.exportModule = function(namespace, moduleName, module, onError) {
 
 /**
  * Add a resource resolver.
- * @param resourceLocationResolver The resource resolver.
+ * @param {ResourceLocationResolver} resourceLocationResolver The resource resolver.
  */
 exports.addResourceLocationResolver = function(resourceLocationResolver) {
     internal.addResourceLocationResolver(resourceLocationResolver);
 };
 
 /**
+ * Get the ResourceLocationResolver function for the supplied ModuleSpec.
+ * @param {ModuleSpec} moduleSpec The ModuleSpec.
+ * @returns {function} The ResourceLocationResolver function for the supplied
+ * ModuleSpec, or null if none specified.
+ */
+exports.getResourceLocationResolver = function (moduleSpec) {
+    if (typeof moduleSpec === 'string') {
+        moduleSpec = new ModuleSpec(moduleSpec);
+    }
+    return internal.getResourceLocationResolverFunc(moduleSpec);
+};
+
+/**
  * Add a module's CSS to the browser page.
- * 
+ *
  * <p>
  * The assumption is that the CSS can be accessed at e.g.
  * {@code <rootURL>/plugin/<namespace>/jsmodules/<moduleName>/style.css} i.e.
  * the pluginId acts as the namespace.
- * 
+ *
  * @param namespace The namespace in which the module resides.
- * @param moduleName The name of the module. 
+ * @param moduleName The name of the module.
  * @param onError On error callback;
  */
 exports.addModuleCSSToPage = function(namespace, moduleName, onError) {
@@ -214,9 +227,9 @@ exports.addModuleCSSToPage = function(namespace, moduleName, onError) {
 
 /**
  * Add a plugin CSS file to the browser page.
- * 
+ *
  * @param pluginName The Jenkins plugin in which the module resides.
- * @param cssPath The CSS path. 
+ * @param cssPath The CSS path.
  * @param onError On error callback;
  */
 exports.addPluginCSSToPage = function(pluginName, cssPath, onError) {
@@ -241,8 +254,8 @@ exports.toCSSId = function (cssPath, namespace) {
 
 /**
  * Add CSS file to the browser page.
- * 
- * @param cssPath The CSS path. 
+ *
+ * @param cssPath The CSS path.
  * @param onError On error callback;
  */
 exports.addCSSToPage = function(cssPath, onError) {
@@ -271,7 +284,7 @@ exports.addCSSToPage = function(cssPath, onError) {
  *     <li><strong>error</strong>: An optional onload error function for the script element. This is called if the .js file exists but there's an error evaluating the script. It is NOT called if the .js file doesn't exist (ala 404).</li>
  *     <li><strong>removeElementOnLoad</strong>: Remove the script element after loading the script. Default is 'false'.</li>
  * </ul>
- * 
+ *
  * @param scriptSrc The script src.
  * @param options Optional script load options object. See above.
  */
@@ -290,7 +303,7 @@ exports.setRegisterTimeout = function(timeout) {
 
 /**
  * Set the Jenkins root/base URL.
- * 
+ *
  * @param rootUrl The root/base URL.
  */
 exports.setRootURL = function(rootUrl) {

--- a/js/index.js
+++ b/js/index.js
@@ -182,6 +182,14 @@ exports.exportModule = function(namespace, moduleName, module, onError) {
 };
 
 /**
+ * Add a resource resolver.
+ * @param resourceLocationResolver The resource resolver.
+ */
+exports.addResourceLocationResolver = function(resourceLocationResolver) {
+    internal.addResourceLocationResolver(resourceLocationResolver);
+};
+
+/**
  * Add a module's CSS to the browser page.
  * 
  * <p>

--- a/js/index.js
+++ b/js/index.js
@@ -199,7 +199,13 @@ exports.getResourceLocationResolver = function (moduleSpec) {
     if (typeof moduleSpec === 'string') {
         moduleSpec = new ModuleSpec(moduleSpec);
     }
-    return internal.getResourceLocationResolverFunc(moduleSpec);
+    var resolver = internal.getResourceLocationResolverFunc(moduleSpec);
+    if (resolver) {
+        return function(resourcePath) {
+            return resolver(moduleSpec, resourcePath);
+        }
+    }
+    return undefined;
 };
 
 /**

--- a/js/index.js
+++ b/js/index.js
@@ -268,6 +268,9 @@ exports.addCSSToPage = function(cssPath, onError) {
     try {
         if (cssPath.indexOf(internal.getAdjunctURL()) === 0) {
             internal.addCSSToPage(undefined, cssPath);
+        } else if (cssPath.indexOf('http://') === 0 || cssPath.indexOf('https://') === 0) {
+            // the css path is already fully qualified
+            internal.addCSSToPage(undefined, cssPath);
         } else {
             internal.addCSSToPage(undefined, internal.getRootURL() + '/' + cssPath);
         }

--- a/js/internal.js
+++ b/js/internal.js
@@ -570,6 +570,7 @@ function getResourceLocationResolverFunc(moduleSpec) {
 
     return undefined;
 }
+exports.getResourceLocationResolverFunc = getResourceLocationResolverFunc;
 
 function getScriptId(scriptSrc, config) {
     if (typeof config === 'string') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-modules",
-  "version": "0.0.10-tf-beta-3",
+  "version": "0.0.10",
   "description": "Jenkins CI JavaScript module bundle loader",
   "main": "js/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-modules",
-  "version": "0.0.10-tf-beta-2",
+  "version": "0.0.10-tf-beta-3",
   "description": "Jenkins CI JavaScript module bundle loader",
   "main": "js/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-modules",
-  "version": "0.0.9",
+  "version": "0.0.10-tf-beta-1",
   "description": "Jenkins CI JavaScript module bundle loader",
   "main": "js/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/js-modules",
-  "version": "0.0.10-tf-beta-1",
+  "version": "0.0.10-tf-beta-2",
   "description": "Jenkins CI JavaScript module bundle loader",
   "main": "js/index.js",
   "scripts": {

--- a/spec/index-spec.js
+++ b/spec/index-spec.js
@@ -99,6 +99,50 @@ describe("index.js", function () {
         });
     });
 
+    it("- test import from some other location", function (done) {
+        testUtil.onJenkinsPage(function() {
+            var jenkins = require("../js/index");
+            var ResourceLocationResolver = require('../js/ResourceLocationResolver');
+
+            jenkins.addResourceLocationResolver(
+                new ResourceLocationResolver(function(moduleSpec) {
+                    return (moduleSpec.namespace === 'pluginXternal');
+                }, function(moduleSpec, srcPath) {
+                    // Should result in the pluginXternal bundles getting loaded from
+                    // http://resources.acme.com/javascript/ .
+                    // See assertion check below.
+                    return "http://resources.acme.com/javascript/" + srcPath;
+                })
+            );
+
+            // Should pass immediately because export has already happened.
+            jenkins.importModule('pluginXternal:mathUtils', 0).onFulfilled(function(module) {
+                expect(module.add(2,2)).toBe(4);
+
+                var document = window.document;
+                var internal = require("../js/internal");
+                var moduleId = internal.toModuleId('pluginXternal', 'mathUtils') + ':js';
+
+                var scriptEl = document.getElementById(moduleId);
+
+                expect(scriptEl).toBeDefined();
+                // Check that the bundle resource was loaded from the other place.
+                // See the earlier call to jenkins.addResourceLocationResolver().
+                expect(scriptEl.getAttribute('src')).toBe('http://resources.acme.com/javascript/mathUtils.js');
+
+                done();
+            }); // disable async load mode
+
+
+            // Register the module before calling require. See above test too.
+            jenkins.exportModule('pluginXternal', 'mathUtils', {
+                add: function(lhs, rhs) {
+                    return lhs + rhs;
+                }
+            });
+        });
+    });
+
     it("- test import and export async successful", function (done) {
         testUtil.onJenkinsPage(function() {
             var jenkins = require("../js/index");

--- a/spec/index-spec.js
+++ b/spec/index-spec.js
@@ -544,7 +544,7 @@ describe("index.js", function () {
         });
     });
     
-    it("- test addCSSToPage", function (done) {
+    it("- test addCSSToPage - on Jenkins host", function (done) {
         testUtil.onJenkinsPage(function() {
             var jenkins = require("../js/index");
             var document = window.document;
@@ -558,6 +558,42 @@ describe("index.js", function () {
             expect(cssEl).toBeDefined();
             expect(cssEl.getAttribute('href')).toBe('/jenkins/css/mathUtils.css');
             
+            done();
+        });
+    });
+
+    it("- test addCSSToPage - qualified URL - http", function (done) {
+        testUtil.onJenkinsPage(function() {
+            var jenkins = require("../js/index");
+            var document = window.document;
+            var cssId = 'jenkins-js-module:global:css:http://acme.com/css/mathUtils.css';
+
+            var cssEl = document.getElementById(cssId);
+            expect(cssEl).toBe(null);
+
+            jenkins.addCSSToPage('http://acme.com/css/mathUtils.css');
+            cssEl = document.getElementById(cssId);
+            expect(cssEl).toBeDefined();
+            expect(cssEl.getAttribute('href')).toBe('http://acme.com/css/mathUtils.css');
+
+            done();
+        });
+    });
+
+    it("- test addCSSToPage - qualified URL - https", function (done) {
+        testUtil.onJenkinsPage(function() {
+            var jenkins = require("../js/index");
+            var document = window.document;
+            var cssId = 'jenkins-js-module:global:css:https://acme.com/css/mathUtils.css';
+
+            var cssEl = document.getElementById(cssId);
+            expect(cssEl).toBe(null);
+
+            jenkins.addCSSToPage('https://acme.com/css/mathUtils.css');
+            cssEl = document.getElementById(cssId);
+            expect(cssEl).toBeDefined();
+            expect(cssEl.getAttribute('href')).toBe('https://acme.com/css/mathUtils.css');
+
             done();
         });
     });


### PR DESCRIPTION
Changes to allow `js-modules` to load resources from "other" places, with "other" being whatever the added `ResourceLocationResolver` impls decide it to be e.g. loading the resources from a completely different host address (Vs that of the Jenkins master).